### PR TITLE
Reset solver metrics before each run

### DIFF
--- a/iterative_solvers.py
+++ b/iterative_solvers.py
@@ -17,9 +17,15 @@ grad_call_times = []
 ls_call_times   = []
 ls_call_iters   = []
 
+def reset_metrics() -> None:
+    """Clear all recorded solver metrics."""
+    grad_call_times.clear()
+    ls_call_times.clear()
+    ls_call_iters.clear()
+
 def get_metrics():
     """
-    Return timing statistics for ISTA:
+    Return timing statistics collected during the last solver run:
       - total/mean gradient evaluation time
       - total/mean line-search time and total line-search iterations
     """
@@ -69,6 +75,7 @@ def ista(
     tol: float = 0.0,
     return_history: bool = False,
 ) -> tuple[np.ndarray, dict] | np.ndarray:
+    reset_metrics()
     x = x0.copy()
     # initial step-size
     t = t_init_factor / L   # UPDATED
@@ -138,6 +145,7 @@ def fista(
     restart_threshold: float  = 1.0,
     return_history: bool      = False,
 ) -> tuple[np.ndarray, dict] | np.ndarray:
+    reset_metrics()
     n      = A.shape[1]
     x_k    = np.zeros(n)
     y_k    = x_k.copy()
@@ -253,6 +261,7 @@ def fista_delta(
         tol_ratio: float = 0.0,
         return_history: bool = False,
 ) -> tuple[np.ndarray, dict] | np.ndarray:
+    reset_metrics()
     # Course requirement: delta > 2 for convergence guarantee
     assert delta > 2, "In FISTA-Δ, delta must be > 2 for convergence (course requirement)"
     m, n = A.shape

--- a/lbfgs.py
+++ b/lbfgs.py
@@ -2,7 +2,7 @@ import numpy as np
 from scipy.optimize import fmin_l_bfgs_b
 from objective_functions import compute_objective
 import time
-from iterative_solvers import grad_call_times
+from iterative_solvers import grad_call_times, reset_metrics
 
 class LBFGSSolver:
     """L-BFGS for Ridge and smooth Elastic-Net, with tiny-α shortcut."""
@@ -39,6 +39,7 @@ class LBFGSSolver:
         self.history_ = []
 
     def fit(self, A, b):
+        reset_metrics()
         def fg(x):
             # 1) time the smooth-part gradient exactly like in ISTA/FISTA
             t0 = time.perf_counter()


### PR DESCRIPTION
## Summary
- add `reset_metrics` utility to clear timing lists
- invoke `reset_metrics` at start of ISTA, FISTA, FISTA-Δ, and L-BFGS runs

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_6898caa707e88329905df3cfa4512025